### PR TITLE
[breaking] Loosen `Sync` requirements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 
 use std::cell::UnsafeCell;
 use std::fmt;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 enum ThisOrThat<T, U> {
     This(T),
@@ -76,7 +76,8 @@ impl<T, U> LazyTransform<T, U> {
     /// The closure can only ever be called once, so think carefully about what
     /// transformation you want to apply!
     pub fn get_or_create<F>(&self, f: F) -> &U
-        where F: FnOnce(T) -> U
+    where
+        F: FnOnce(T) -> U,
     {
         // In addition to being correct, this pattern is vouched for by Hans Boehm
         // (http://schd.ws/hosted_files/cppcon2016/74/HansWeakAtomics.pdf Page 27)
@@ -163,7 +164,8 @@ impl<T> Lazy<T> {
     /// The value stored in the `Lazy<T>` is immutable after the closure returns
     /// it, so think carefully about what you want to put inside!
     pub fn get_or_create<F>(&self, f: F) -> &T
-        where F: FnOnce() -> T
+    where
+        F: FnOnce() -> T,
     {
         self.inner.get_or_create(|_| f())
     }
@@ -181,12 +183,15 @@ impl<T> Lazy<T> {
 // is too restrictive, because `Lazy<T>` always has a default value for any `T`.
 impl<T> Default for Lazy<T> {
     fn default() -> Self {
-        Lazy { inner: LazyTransform::new(()) }
+        Lazy {
+            inner: LazyTransform::new(()),
+        }
     }
 }
 
 impl<T> fmt::Debug for Lazy<T>
-    where T: fmt::Debug + Sync
+where
+    T: fmt::Debug + Sync,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(v) = self.get() {
@@ -203,10 +208,10 @@ extern crate scoped_pool;
 #[cfg(test)]
 mod tests {
 
-    use scoped_pool::Pool;
-    use std::{thread, time};
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use super::{Lazy, LazyTransform};
+    use scoped_pool::Pool;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::{thread, time};
 
     #[test]
     fn test_lazy() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,7 @@ pub struct LazyTransform<T, U> {
 }
 
 // Implementation details.
-impl<T, U> LazyTransform<T, U>
-    where T: Sync,
-          U: Sync
-{
+impl<T, U> LazyTransform<T, U> {
     fn extract(&self) -> Option<&U> {
         // Make sure we're initialized first!
         match unsafe { (*self.value.get()).as_ref() } {
@@ -69,10 +66,7 @@ impl<T, U> LazyTransform<T, U> {
 }
 
 // Public API.
-impl<T, U> LazyTransform<T, U>
-    where T: Sync,
-          U: Sync
-{
+impl<T, U> LazyTransform<T, U> {
     /// Get a reference to the transformed value, invoking `f` to transform it
     /// if the `LazyTransform<T, U>` has yet to be transformed.  It is
     /// guaranteed that if multiple calls to `get_or_create` race, only one
@@ -124,15 +118,17 @@ impl<T, U> LazyTransform<T, U>
     }
 }
 
+// As `T` is only ever accessed when locked, it's enough if it's `Send` for `Self` to be `Sync`.
 unsafe impl<T, U> Sync for LazyTransform<T, U>
-    where T: Sync + Send,
-          U: Sync
+where
+    T: Send,
+    U: Sync,
 {
 }
 
 impl<T, U> Default for LazyTransform<T, U>
-    where T: Sync + Default,
-          U: Sync
+where
+    T: Default,
 {
     fn default() -> Self {
         LazyTransform::new(T::default())
@@ -158,9 +154,7 @@ impl<T> Lazy<T> {
     }
 }
 
-impl<T> Lazy<T>
-    where T: Sync
-{
+impl<T> Lazy<T> {
     /// Get a reference to the contained value, invoking `f` to create it
     /// if the `Lazy<T>` is uninitialized.  It is guaranteed that if multiple
     /// calls to `get_or_create` race, only one will invoke its closure, and


### PR DESCRIPTION
Thanks for making this crate! It's exactly what I need for my web framework project.

However, I'm hitting a few snags related to `Sync` bounds on various methods, which aren't necessary with appropriate constraints on this type's `unsafe impl Sync`. This pull request removes them where possible and as such closes #10.

Note that this is unrelated to #9, which I'll make a separate pull request for in a moment.