### PR TITLE
[breaking] Soundness fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ impl<T, U> LazyTransform<T, U>
 
 unsafe impl<T, U> Sync for LazyTransform<T, U>
     where T: Sync + Send,
-          U: Sync
+          U: Send + Sync
 {
 }
 


### PR DESCRIPTION
As per the issue, a `Send` bound is required on `U` when implementing `Sync` to make sure references aren't accessible on threads other than the one the `U` was created on. This pull-request fixes #9.