### PR TITLE
[breaking?] Remove Sync requirement on impl Debug for Lazy<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ impl<T> Default for Lazy<T> {
 
 impl<T> fmt::Debug for Lazy<T>
 where
-    T: fmt::Debug + Sync,
+    T: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(v) = self.get() {


### PR DESCRIPTION
Sorry, I missed one extra `Sync` clause when removing them for #15.

This pull request removes the `T: Sync` bound on `impl<T> fmt::Debug for Lazy<T>`, since the necessary threading constraints are already inherited from `LazyTransform<(), T>`. With this change, there should be no remaining rough edges specific to single-threaded consumers of this library.