### PR TITLE
Implement PartialEq

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,15 @@ where
     }
 }
 
+impl<T> PartialEq for Lazy<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
 #[cfg(test)]
 extern crate rayon;
 


### PR DESCRIPTION
This allows `Lazy<T>` to be part of structs which implement `PartialEq` (eg. via `#[derive(PartialEq)]`).